### PR TITLE
Fixed issue where FROM wasn't being parsed properly

### DIFF
--- a/Trace Wizard/Data/SQLStatement.cs
+++ b/Trace Wizard/Data/SQLStatement.cs
@@ -119,12 +119,12 @@ namespace TraceWizard.Data
             {
                 WhereClause = "";
             }
-            
+             
         }
 
         private void ParseFromClause()
         {
-            Regex fromClause = new Regex("(FROM|UPDATE) (.*?) (SET|WHERE|ORDER|$)",RegexOptions.IgnoreCase);
+            Regex fromClause = new Regex("(FROM|UPDATE)\\s*(.*?)\\s*(SET|WHERE|ORDER|$)",RegexOptions.IgnoreCase);
             FromClause = fromClause.Match(Statement).Groups[2].Value.Trim();
         }
 


### PR DESCRIPTION
FROM would fail to parse if there wasn't at least 1 space after the
table name.
