### PR TITLE
Remove ListItemViewComparer on SQL View when filtering items.

### DIFF
--- a/Trace Wizard/UI/MainForm.cs
+++ b/Trace Wizard/UI/MainForm.cs
@@ -1148,6 +1148,8 @@ namespace TraceWizard
 
             menu.Checked = currentStatus;
 
+            /* Remove the ListItemViewComparer if one is present */
+            sqlListView.ListViewItemSorter = null;
 
             if (sender == allToolStripMenuItem)
             {


### PR DESCRIPTION
This is because depending on the filter the number of columns might change leaving an invalid Comparer on the ListView.

This fixes bug #6
